### PR TITLE
Adds `Head` and `Body` methods

### DIFF
--- a/fluentrequest.go
+++ b/fluentrequest.go
@@ -1,18 +1,21 @@
 package fluentrequest
 
 import (
+	"io"
 	"net/http"
 )
 
 func FluentRequest() *fluentRequest {
 	return &fluentRequest{
-	client: http.Client{},
+		client: http.Client{},
 	}
 }
 
 type fluentRequest struct {
 	url    string
 	method string
+	body   io.Reader
+	header http.Header
 	client http.Client
 }
 
@@ -28,8 +31,25 @@ func (r *fluentRequest) Method(method string) *fluentRequest {
 	return r
 }
 
+func (r *fluentRequest) Body(body io.Reader) *fluentRequest {
+	r.body = body
+
+	return r
+}
+
+func (r *fluentRequest) Header(header map[string][]string) *fluentRequest {
+	r.header = header
+
+	return r
+}
+
 func (r *fluentRequest) Run() (*http.Response, error) {
 
-	req, _ := http.NewRequest(r.method, r.url, nil)
+	req, _ := http.NewRequest(r.method, r.url, r.body)
+
+	if r.header != nil {
+		req.Header = r.header
+	}
+
 	return r.client.Do(req)
 }

--- a/fluentrequest.go
+++ b/fluentrequest.go
@@ -47,9 +47,7 @@ func (r *fluentRequest) Run() (*http.Response, error) {
 
 	req, _ := http.NewRequest(r.method, r.url, r.body)
 
-	if r.header != nil {
-		req.Header = r.header
-	}
+	req.Header = r.header
 
 	return r.client.Do(req)
 }

--- a/fluentrequest_test.go
+++ b/fluentrequest_test.go
@@ -1,6 +1,8 @@
 package fluentrequest
 
 import (
+	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -9,7 +11,10 @@ import (
 )
 
 const (
-	expectedBody = "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"completed\": false\n}"
+	expectedBody      = "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"completed\": false\n}"
+	expectedPOSTBody  = "{\n  \"completed\": false,\n  \"id\": 101,\n  \"title\": \"delectus aut autem\",\n  \"userId\": 1\n}"
+	expectedPUTBody   = "{\n  \"body\": \"bar\",\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"userId\": 1\n}"
+	expectedPATCHBody = "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"foo\",\n  \"body\": \"bar\"\n}"
 )
 
 func TestRequest(t *testing.T) {
@@ -22,5 +27,81 @@ func TestRequest(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBody, string(body))
-	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestPOST(t *testing.T) {
+	data, _ := json.Marshal(map[string]interface{}{
+		"userId":    1,
+		"id":        1,
+		"title":     "delectus aut autem",
+		"completed": false,
+	})
+
+	header := http.Header{
+		"Content-Type": {"application/json; charset=UTF-8"},
+	}
+
+	resp, err := FluentRequest().
+		Method(http.MethodPost).
+		Url("https://jsonplaceholder.typicode.com/posts").
+		Body(bytes.NewBuffer(data)).
+		Header(header).
+		Run()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPOSTBody, string(body))
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestPUT(t *testing.T) {
+	data, _ := json.Marshal(map[string]interface{}{
+		"id":     1,
+		"title":  "delectus aut autem",
+		"body":   "bar",
+		"userId": 1,
+	})
+
+	header := http.Header{
+		"Content-Type": {"application/json; charset=UTF-8"},
+	}
+
+	resp, err := FluentRequest().
+		Method(http.MethodPut).
+		Url("https://jsonplaceholder.typicode.com/posts/1").
+		Body(bytes.NewBuffer(data)).
+		Header(header).
+		Run()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPUTBody, string(body))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestPATCH(t *testing.T) {
+	data, _ := json.Marshal(map[string]interface{}{
+		"title": "foo",
+		"body":  "bar",
+	})
+
+	header := http.Header{
+		"Content-Type": {"application/json; charset=UTF-8"},
+	}
+
+	resp, err := FluentRequest().
+		Method(http.MethodPatch).
+		Url("https://jsonplaceholder.typicode.com/posts/1").
+		Body(bytes.NewBuffer(data)).
+		Header(header).
+		Run()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPATCHBody, string(body))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
Adds `Head` and `Body` methods to `fluentRequest` and adds tests for POST, PUT, and PATCH.

Fixes #1